### PR TITLE
Enable the choice between different scopes of locality caches can be found in

### DIFF
--- a/data/platform-files/sgbatch_nested.xml
+++ b/data/platform-files/sgbatch_nested.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!DOCTYPE platform SYSTEM "http://simgrid.gforge.inria.fr/simgrid/simgrid.dtd">
+<platform version="4.1">
+    <config>
+        <prop id="network/loopback-bw" value="100000000000000"/>
+    </config>
+
+    <zone id="global" routing="Full">
+        <zone id="ETP" routing="Floyd">
+            <zone id="ETPSub1" routing="Floyd">
+                <host id="sg01" speed="1117Mf" core="24">
+                    <prop id="type" value="worker,cache"/>
+                    <prop id="ram" value="64GiB"/>
+                    <disk id="ssd_cache1" read_bw="9.6Gbps" write_bw="9.6Gbps">
+                        <prop id="size" value="2.5TB"/>
+                        <prop id="mount" value="/"/>
+                    </disk>
+                </host>
+                <host id="sg02" speed="1117Mf" core="24">
+                    <prop id="type" value="worker,cache"/>
+                    <prop id="ram" value="64GiB"/>
+                    <disk id="ssd_cache1" read_bw="9.6Gbps" write_bw="9.6Gbps">
+                        <prop id="size" value="2.5TB"/>
+                        <prop id="mount" value="/"/>
+                    </disk>
+                </host>
+
+                <host id="WMSHost" speed="10Gf" core="10">
+                    <prop id="type" value="scheduler,executor"/>
+                    <prop id="ram" value="16GB"/>
+                </host>
+
+                <router id="etpgateway"/>
+
+                <link id="loopback" bandwidth="5000GBps" latency="0us"/>
+                <link id="etp_link" bandwidth="6Gbps" latency="0us"/>
+
+                <route src="etpgateway" dst="WMSHost">
+                    <link_ctn id="etp_link"/>
+                </route>
+                <route src="etpgateway" dst="sg01">
+                    <link_ctn id="etp_link"/>
+                </route>
+                <route src="etpgateway" dst="sg02">
+                    <link_ctn id="etp_link"/>
+                </route>
+                <!-- <route src="etpgateway" dst="sg03">
+                    <link_ctn id="etp_link"/>
+                </route> -->
+                <!-- <route src="sg01" dst="sg01">
+                    <link_ctn id="loopback"/>
+                </route>
+                <route src="sg02" dst="sg02">
+                    <link_ctn id="loopback"/>
+                </route>
+                <route src="sg03" dst="sg03">
+                    <link_ctn id="loopback"/>
+                </route> -->
+            </zone>
+
+            <zone id="ETPSub3" routing="Floyd">
+                <host id="sg03" speed="1258Mf" core="12">
+                    <prop id="type" value="worker,cache"/>
+                    <prop id="ram" value="32GiB"/>
+                    <disk id="ssd_cache1" read_bw="9.6Gbps" write_bw="9.6Gbps">
+                        <prop id="size" value="2.5TB"/>
+                        <prop id="mount" value="/"/>
+                    </disk>
+                </host> 
+            </zone>
+
+            <zoneRoute src="ETPSub1" dst="ETPSub3" gw_src="etpgateway" gw_dst="sg03">
+                <link_ctn id="etp_link"/>
+            </zoneRoute>
+        </zone>
+
+        <zone id="Remote" routing="Full">
+            <host id="RemoteStorage" speed="1000Gf" core="10">
+                <prop id="type" value="storage"/>
+                <disk id="hard_drive" read_bw="40Gbps" write_bw="40Gbps">
+                    <prop id="size" value="1PB"/>
+                    <prop id="mount" value="/"/>
+                </disk>
+            </host>
+
+            <link id="etp_to_remote" bandwidth="10Gbps" latency="0us"/>
+        </zone>
+
+        <zoneRoute src="ETP" dst="Remote" gw_src="etpgateway" gw_dst="RemoteStorage">
+            <link_ctn id="etp_to_remote"/>
+        </zoneRoute>
+    </zone>  
+</platform>

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -41,7 +41,7 @@ std::set<std::string> SimpleSimulator::scheduler_hosts;
 std::set<std::string> SimpleSimulator::executors;
 std::set<std::string> SimpleSimulator::file_registries;
 std::set<std::string> SimpleSimulator::network_monitors;
-std::map<std::string, std::set<std::string>> SimpleSimulator::hosts_in_rec_zones;
+std::map<std::string, std::set<std::string>> SimpleSimulator::hosts_in_zones;
 bool SimpleSimulator::local_cache_scope = false; // flag to consider only local caches
 
 
@@ -253,7 +253,7 @@ void SimpleSimulator::identifyHostTypes(std::shared_ptr<wrench::Simulation> simu
  * which finds all hosts in zone and all subzones
  * and fills them into static map.
  */
-void SimpleSimulator::fillHostsInRecZonesMap() {
+void SimpleSimulator::fillHostsInSameLevelZonesMap() {
     std::map<std::string, std::vector<std::string>> zones_in_zones = wrench::S4U_Simulation::getAllSubZoneIDsByZone();
     std::map<std::string, std::vector< std::string>> hostnames_in_zones = wrench::S4U_Simulation::getAllHostnamesByZone();
     for (const auto& zones_in_zone: zones_in_zones) {
@@ -262,8 +262,8 @@ void SimpleSimulator::fillHostsInRecZonesMap() {
             // std::cerr << "\tSubzone: " << zone << std::endl;
             for (const auto& host: hostnames_in_zones[zone]) {
                 // std::cerr << "\t\tHost: " << host << std::endl;
-                hosts_in_rec_zones[zones_in_zone.first].insert(host);
-                hosts_in_rec_zones[zone].insert(host);
+                hosts_in_zones[zones_in_zone.first].insert(host);
+                hosts_in_zones[zone].insert(host);
             }
         }
 
@@ -346,12 +346,12 @@ int main(int argc, char **argv) {
 
     // Fill reachable caches map
     if (rec_netzone_caches) {
-        SimpleSimulator::fillHostsInRecZonesMap();
+        SimpleSimulator::fillHostsInSameLevelZonesMap();
     } else {
         for (const auto& hostnamesByZone: wrench::S4U_Simulation::getAllHostnamesByZone()) {
             std::vector<std::string> hostnamesVec = hostnamesByZone.second;
             std::set<std::string> hostnamesSet(hostnamesVec.begin(), hostnamesVec.end());
-            SimpleSimulator::hosts_in_rec_zones[hostnamesByZone.first] = hostnamesSet;
+            SimpleSimulator::hosts_in_zones[hostnamesByZone.first] = hostnamesSet;
         }
     }
 

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -19,7 +19,7 @@ public:
     static std::set<std::string> file_registries;   // hosts configured to manage a file registry
     static std::set<std::string> network_monitors;  // hosts configured to monitor network
 
-    static void fillHostsInSameLevelZonesMap();
+    static void fillHostsInSiblingZonesMap(bool include_subzones);
     static bool local_cache_scope;
 
     static std::map<std::string, std::set<std::string>> hosts_in_zones; // map holding information of all hosts present in network zones

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -19,10 +19,10 @@ public:
     static std::set<std::string> file_registries;   // hosts configured to manage a file registry
     static std::set<std::string> network_monitors;  // hosts configured to monitor network
 
-    static void fillHostsInRecZonesMap();
+    static void fillHostsInSameLevelZonesMap();
     static bool local_cache_scope;
 
-    static std::map<std::string, std::set<std::string>> hosts_in_rec_zones; // map holding information of all hosts present in network zones
+    static std::map<std::string, std::set<std::string>> hosts_in_zones; // map holding information of all hosts present in network zones
 
     static bool use_blockstreaming;
     static std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> global_file_map;

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -19,6 +19,10 @@ public:
     static std::set<std::string> file_registries;   // hosts configured to manage a file registry
     static std::set<std::string> network_monitors;  // hosts configured to monitor network
 
+    static void fillHostsInRecZonesMap();
+
+    static std::map<std::string, std::set<std::string>> hosts_in_rec_zones; // map holding information of all hosts present in network zones
+
     static bool use_blockstreaming;
     static std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> global_file_map;
     static double xrd_block_size;

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -20,6 +20,7 @@ public:
     static std::set<std::string> network_monitors;  // hosts configured to monitor network
 
     static void fillHostsInRecZonesMap();
+    static bool local_cache_scope;
 
     static std::map<std::string, std::set<std::string>> hosts_in_rec_zones; // map holding information of all hosts present in network zones
 

--- a/src/computation/CacheComputation.cpp
+++ b/src/computation/CacheComputation.cpp
@@ -54,7 +54,7 @@ void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::Acti
         if (SimpleSimulator::local_cache_scope) {
             host_in_scope = (ss->getHostname() == hostname);
         } else {
-            host_in_scope = (SimpleSimulator::hosts_in_rec_zones[netzone].find(ss->getHostname()) != SimpleSimulator::hosts_in_rec_zones[netzone].end());
+            host_in_scope = (SimpleSimulator::hosts_in_zones[netzone].find(ss->getHostname()) != SimpleSimulator::hosts_in_zones[netzone].end());
         }
         if (host_in_scope) {
             matched_storage_services.push_back(ss);

--- a/src/computation/CacheComputation.cpp
+++ b/src/computation/CacheComputation.cpp
@@ -38,6 +38,8 @@ CacheComputation::CacheComputation(std::set<std::shared_ptr<wrench::StorageServi
 void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::ActionExecutor> action_executor) {
 
     std::string hostname = action_executor->getHostname(); // host where action is executed
+    auto host = simgrid::s4u::Host::by_name(hostname); 
+    std::string netzone = host->get_englobing_zone()->get_name(); // network zone executing host belongs to
     auto the_action = std::dynamic_pointer_cast<MonitorAction>(action_executor->getAction()); // executed action
 
     double cached_data_size = 0.;
@@ -45,10 +47,16 @@ void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::Acti
 
     // Identify all cache storage services that can be reached from 
     // this host, which runs the streaming action
-    //TODO: Think of a better definition of "reachable" other than local
     std::vector<std::shared_ptr<wrench::StorageService>> matched_storage_services;
+
     for (auto const &ss : this->cache_storage_services) {
-        if (ss->getHostname() == hostname) {
+        bool host_in_scope = false;
+        if (SimpleSimulator::local_cache_scope) {
+            host_in_scope = (ss->getHostname() == hostname);
+        } else {
+            host_in_scope = (SimpleSimulator::hosts_in_rec_zones[netzone].find(ss->getHostname()) != SimpleSimulator::hosts_in_rec_zones[netzone].end());
+        }
+        if (host_in_scope) {
             matched_storage_services.push_back(ss);
             WRENCH_DEBUG("Found a reachable cache on host %s", ss->getHostname().c_str());
         }


### PR DESCRIPTION
This includes a feature to chose between different levels of locality hosts can find a cache. Particularily, it gives the user the option to chose between three global scenarios:
1. **local** caches: jobs will only find a cache, when it is on the executing machine
2. **network** caches: jobs will search for caches in the same network zone
3. **siblingnetwork** caches: jobs will also search for caches in zones with the same parent zone as the one the host running the job lives in
