### PR TITLE
Add a flag to switch caching on and off and factorize duplications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ set(TEST_FILES
 
 # wrench library and dependencies
 find_library(WRENCH_LIBRARY NAMES wrench)
-find_library(PUGIXML_LIBRARY NAMES pugixml)
 find_library(GTEST_LIBRARY NAMES gtest)
 find_library(SimGrid_LIBRARY NAMES simgrid)
 
@@ -61,14 +60,12 @@ target_link_libraries(sgbatch-sim
                        ${WRENCH_LIBRARY}
                        ${SimGrid_LIBRARY}
                        ${Boost_LIBRARIES}
-                       ${PUGIXML_LIBRARY}
                       -lzmq )
 else()
 target_link_libraries(sgbatch-sim
                        ${WRENCH_LIBRARY}
                        ${SimGrid_LIBRARY}
                        ${Boost_LIBRARIES}
-                       ${PUGIXML_LIBRARY}
                       )
 endif()
 

--- a/data/platform-files/sgbatch_validation.xml
+++ b/data/platform-files/sgbatch_validation.xml
@@ -7,34 +7,34 @@
 
     <zone id="global" routing="Full">
         <zone id="ETP" routing="Floyd">
-            <host id="sg01.etp.kit.edu" speed="1969.583Mf" core="24">
+            <host id="sg01.etp.kit.edu" speed="1040f" core="24">
                 <prop id="type" value="worker,cache"/>
                 <prop id="ram" value="64GiB"/>
-                <disk id="ssd_cache1" read_bw="0.75GBps" write_bw="0.75GBps">
+                <disk id="ssd_cache1" read_bw="1.0GBps" write_bw="1.0GBps">
                     <prop id="size" value="2TB"/>
                     <prop id="mount" value="/"/>
                 </disk>
             </host>
-            <!-- <host id="sg02.etp.kit.edu" speed="1969.583Mf" core="24">
+            <host id="sg02.etp.kit.edu" speed="1969.583Mf" core="24">
                 <prop id="type" value="networkmonitor"/>
                 <prop id="ram" value="64GiB"/>
-                <disk id="ssd_cache1" read_bw="0.75GBps" write_bw="0.75GBps">
-                    <prop id="size" value="2TB"/>
-                    <prop id="mount" value="/"/>
-                </disk>
-            </host> -->
-            <host id="sg03.etp.kit.edu" speed="1971.000Mf" core="12">
-                <prop id="type" value="worker,cache"/>
-                <prop id="ram" value="32GiB"/>
-                <disk id="ssd_cache1" read_bw="0.75GBps" write_bw="0.75GBps">
+                <disk id="ssd_cache1" read_bw="0.12GBps" write_bw="0.12GBps">
                     <prop id="size" value="2TB"/>
                     <prop id="mount" value="/"/>
                 </disk>
             </host>
-            <host id="sg04.etp.kit.edu" speed="1966.674Mf" core="12">
+            <host id="sg03.etp.kit.edu" speed="1000f" core="12">
                 <prop id="type" value="worker,cache"/>
                 <prop id="ram" value="32GiB"/>
-                <disk id="ssd_cache1" read_bw="0.75GBps" write_bw="0.75GBps">
+                <disk id="ssd_cache1" read_bw="1.0GBps" write_bw="1.0GBps">
+                    <prop id="size" value="2TB"/>
+                    <prop id="mount" value="/"/>
+                </disk>
+            </host>
+            <host id="sg04.etp.kit.edu" speed="1000f" core="12">
+                <prop id="type" value="worker,cache"/>
+                <prop id="ram" value="32GiB"/>
+                <disk id="ssd_cache1" read_bw="1.0GBps" write_bw="1.0GBps">
                     <prop id="size" value="2TB"/>
                     <prop id="mount" value="/"/>
                 </disk>
@@ -50,9 +50,9 @@
             <link id="loopback" bandwidth="5000GBps" latency="0us"/>
             <link id="etp_link0" bandwidth="10Gbps" latency="0us"/>
             <link id="etp_link1" bandwidth="10Gbps" latency="0us"/>
-            <!-- <link id="etp_link2up" bandwidth="10Gbps" latency="0us"/>
-            <link id="etp_link2down" bandwidth="10Gbps" latency="0us"/> -->
-            <link id="etp_linkOut" bandwidth="10Gbps" latency="0us"/>
+            <link id="etp_link2up" bandwidth="11.5Gbps" latency="0us"/>
+            <link id="etp_link2down" bandwidth="11.5Gbps" latency="0us"/>
+            <link id="etp_linkOut" bandwidth="1.6Gbps" latency="0us"/>
             <link id="etp_link3" bandwidth="10Gbps" latency="0us"/>
             <link id="etp_link4" bandwidth="10Gbps" latency="0us"/>
 
@@ -68,15 +68,15 @@
             <route src="etpswitch" dst="sg03.etp.kit.edu">
                 <link_ctn id="etp_link3"/>
             </route>
-            <!-- <route src="etpswitch" dst="sg02.etp.kit.edu">
+            <route src="etpswitch" dst="sg02.etp.kit.edu">
                 <link_ctn id="etp_link2up"/>
-            </route> -->
-            <!-- <route src="etpgateway" dst="sg02.etp.kit.edu">
-                <link_ctn id="etp_link2down"/>
-            </route> -->
-            <route src="etpgateway" dst="etpswitch">
-                <link_ctn id="etp_linkOut"/>
             </route>
+            <route src="etpgateway" dst="sg02.etp.kit.edu">
+                <link_ctn id="etp_link2down"/>
+            </route>
+            <!-- <route src="etpgateway" dst="etpswitch">
+                <link_ctn id="etp_linkOut"/>
+            </route> -->
         </zone>
 
         <zone id="Remote" routing="Full">

--- a/src/SimpleExecutionController.cpp
+++ b/src/SimpleExecutionController.cpp
@@ -145,29 +145,29 @@ int SimpleExecutionController::main() {
         }
 
         // Create the file write action
-        auto fw_action = job->addFileWriteAction(
-            "file_write_" + job_name,
-            job_spec->outfile,
-            job_spec->outfile_destination
-        );
-        //TODO: Think of a determination of storage_service to hold output data
-        // auto fw_action = job->addCustomAction(
+        // auto fw_action = job->addFileWriteAction(
         //     "file_write_" + job_name,
-        //     job_spec->total_mem, 0,
-        //     [](std::shared_ptr<wrench::ActionExecutor> action_executor) {
-        //         // TODO: Which storage service should we write output on?
-        //         // TODO: Probably random selection is fine, or just a fixed
-        //         // TODO: one that's picked by the "user"?
-        //         // TODO: Write the file at once
-        //     },
-        //     [](std::shared_ptr<wrench::ActionExecutor> action_executor) {
-        //         WRENCH_INFO("Output file was successfully written!")
-        //         // Do nothing
-        //     }
+        //     job_spec->outfile,
+        //     job_spec->outfile_destination
         // );
+        // //TODO: Think of a determination of storage_service to hold output data
+        // // auto fw_action = job->addCustomAction(
+        // //     "file_write_" + job_name,
+        // //     job_spec->total_mem, 0,
+        // //     [](std::shared_ptr<wrench::ActionExecutor> action_executor) {
+        // //         // TODO: Which storage service should we write output on?
+        // //         // TODO: Probably random selection is fine, or just a fixed
+        // //         // TODO: one that's picked by the "user"?
+        // //         // TODO: Write the file at once
+        // //     },
+        // //     [](std::shared_ptr<wrench::ActionExecutor> action_executor) {
+        // //         WRENCH_INFO("Output file was successfully written!")
+        // //         // Do nothing
+        // //     }
+        // // );
 
-        // Add necessary dependencies
-        job->addActionDependency(run_action, fw_action);
+        // // Add necessary dependencies
+        // job->addActionDependency(run_action, fw_action);
 
         // Submit the job for execution!
         //TODO: generalize to arbitrary numbers of htcondor services

--- a/src/SimpleExecutionController.h
+++ b/src/SimpleExecutionController.h
@@ -33,8 +33,12 @@ public:
               //const double& hitrate,
               const std::string& outputdump_name);
 
-    std::map<std::string, JobSpecification>& get_workload_spec() {
-        return workload_spec;
+    std::map<std::string, JobSpecification> get_workload_spec() {
+        return this->workload_spec;
+    }
+
+    void set_workload_spec(std::map<std::string, JobSpecification> w) {
+        this->workload_spec = w;
     }
 
 

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -412,7 +412,7 @@ int main(int argc, char **argv) {
 
     // Choice of cache locality scope
     std::string scope_caches = vm["cache-scope"].as<cacheScope>().value;
-    bool rec_netzone_caches;
+    bool rec_netzone_caches = false;
     if (scope_caches.find("network") == std::string::npos) {
         SimpleSimulator::local_cache_scope = true;
     } else {

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -28,6 +28,7 @@ namespace po = boost::program_options;
 std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> SimpleSimulator::global_file_map;
 std::mt19937 SimpleSimulator::gen(42);  // random number generator
 bool SimpleSimulator::use_blockstreaming = true;   // flag to chose between simulated job types: streaming or copy jobs
+bool SimpleSimulator::infile_caching_on = true; // flag to turn off/on the caching of job input-files
 bool SimpleSimulator::prefetching_on = true;   // flag to enable prefetching during streaming
 double SimpleSimulator::xrd_block_size = 1.*1000*1000*1000; // maximum size of the streamed file blocks in bytes for the XRootD-ish streaming
 // TODO: The initialized below is likely bogus (at compile time?)
@@ -114,6 +115,7 @@ po::variables_map process_program_options(int argc, char** argv) {
     size_t duplications = 1;
 
     bool no_blockstreaming = false;
+    bool no_caching = false;
     bool prefetch_off = false;
 
     double xrd_block_size = 1000.*1000*1000;
@@ -139,6 +141,7 @@ po::variables_map process_program_options(int argc, char** argv) {
         ("duplications,d", po::value<size_t>()->default_value(duplications), "number of duplications of the workflow to feed into the simulation")
 
         ("no-streaming", po::bool_switch()->default_value(no_blockstreaming), "switch to turn on/off block-wise streaming of input-files")
+        ("no-caching", po::bool_switch()->default_value(no_caching), "switch to turn on/off the caching of jobs' input-files")
         ("prefetch-off", po::bool_switch()->default_value(prefetch_off), "switch to turn on/off prefetching for streaming of input-files")
 
         ("output-file,o", po::value<std::string>()->value_name("<out file>")->required(), "path for the CSV file containing output information about the jobs in the simulation")
@@ -371,7 +374,10 @@ int main(int argc, char **argv) {
     // Flags to turn on/off blockwise streaming of input-files
     SimpleSimulator::use_blockstreaming = !(vm["no-streaming"].as<bool>());
 
-    // Flags to turn refetching for streaming of input-files
+    // Flags to turn on/off the caching of jobs' input-files
+    SimpleSimulator::infile_caching_on = !(vm["no-caching"].as<bool>());
+
+    // Flags to turn prefetching for streaming of input-files
     std::cerr << "Prefetching switch off?: " << vm["prefetch-off"].as<bool>() << std::endl;
     SimpleSimulator::prefetching_on = !(vm["prefetch-off"].as<bool>());
 

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -25,6 +25,7 @@ public:
     static std::map<std::string, std::set<std::string>> hosts_in_zones; // map holding information of all hosts present in network zones
 
     static bool use_blockstreaming;
+    static bool infile_caching_on;
     static bool prefetching_on;
     static std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> global_file_map;
     static double xrd_block_size;

--- a/src/computation/CacheComputation.h
+++ b/src/computation/CacheComputation.h
@@ -19,7 +19,7 @@ public:
 
     virtual ~CacheComputation() = default;
 
-    void determineFileSourcesAndCache(std::shared_ptr<wrench::ActionExecutor> action_executor);
+    void determineFileSourcesAndCache(std::shared_ptr<wrench::ActionExecutor> action_executor, bool cache_files);
 
     void operator () (std::shared_ptr<wrench::ActionExecutor> action_executor);
 


### PR DESCRIPTION
This PR adds an option to turn on/off the caching of input-files and also factorizes the workload creation and the duplication, in order to get dependent input-files.

This enables the execution of exactly the same jobs, without changing the initial hitrate of input-files on the caches.